### PR TITLE
Add HUD network metrics and flatbuffers npm task

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,9 @@ The static web client (`static_client/`) uses JavaScript code generated from the
 * The pre-generated JavaScript files are located in `static_client/generated_js/`.
 * If you modify the FlatBuffers schema (`server/schemas/game.fbs`), you need to regenerate these client-side files. Run the script:
     ```bash
-    cd scripts
-    ./generate_flatbuffers.sh
+    npm run generate:flatbuffers
     ```
-    This script uses `flatc` to generate TypeScript files and then (optionally, if `tsc` is installed) compiles them to JavaScript.
+    This script runs `scripts/generate_flatbuffers.sh`, which uses `flatc` to generate TypeScript files and then (optionally, if `tsc` is installed) compiles them to JavaScript.
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "massive-game-server-client-tools",
+  "version": "0.1.0",
+  "scripts": {
+    "generate:flatbuffers": "bash scripts/generate_flatbuffers.sh"
+  }
+}

--- a/static_client/client.html
+++ b/static_client/client.html
@@ -135,6 +135,10 @@
                             <p>K/D: <span id="playerKills" class="text-red-400">0</span>/<span id="playerDeaths" class="text-gray-400">0</span></p>
                             <p>Players: <span id="playerCount" class="text-gray-100">0</span></p>
                             <p>Ping: <span id="pingDisplay" class="text-gray-100">0</span>ms</p>
+                            <p>Tick: <span id="serverTickDisplay" class="text-gray-100">0</span>Hz</p>
+                            <p>Down: <span id="downloadRateDisplay" class="text-gray-100">0</span> KB/s</p>
+                            <p>Up: <span id="uploadRateDisplay" class="text-gray-100">0</span> KB/s</p>
+                            <p>FPS: <span id="fpsHudDisplay" class="text-gray-100">0</span></p>
                         </div>
                         <div id="powerupStatus" class="mt-2 space-y-1"></div>
                         <div id="networkQualityIndicator" class="mt-2"></div>
@@ -321,6 +325,10 @@
         const playerDeathsSpan = document.getElementById('playerDeaths');
         const playerCountSpan = document.getElementById('playerCount');
         const powerupStatusDiv = document.getElementById('powerupStatus');
+        const serverTickDisplay = document.getElementById('serverTickDisplay');
+        const downloadRateDisplay = document.getElementById('downloadRateDisplay');
+        const uploadRateDisplay = document.getElementById('uploadRateDisplay');
+        const fpsHudDisplay = document.getElementById('fpsHudDisplay');
 
         let starfield;
         let healthVignette;
@@ -386,6 +394,12 @@
         let ping = 0;
         let frameCount = 0;
         let lastFPSUpdate = 0;
+        let downloadBytes = 0;
+        let uploadBytes = 0;
+        let lastNetworkStatTime = 0;
+        let downloadRate = 0;
+        let uploadRate = 0;
+        let serverTickRate = SERVER_TICK_RATE;
 
         // Managers
         let effectsManager;
@@ -1902,6 +1916,14 @@ function drawEnhancedWallCracks(wall, healthPercent) {
                 lastFPSUpdate = currentTime;
             }
 
+            if (currentTime - lastNetworkStatTime >= 1000) {
+                downloadRate = downloadBytes / 1024;
+                uploadRate = uploadBytes / 1024;
+                downloadBytes = 0;
+                uploadBytes = 0;
+                lastNetworkStatTime = currentTime;
+            }
+
             if (localPlayerState && localPlayerState.alive) {
                 updateLocalPlayerPrediction(app.ticker.deltaMS / 1000);
             }
@@ -2844,6 +2866,7 @@ function drawEnhancedWallCracks(wall, healthPercent) {
 
             const bytes = createInputMessage(currentFrameInput);
             dataChannel.send(bytes);
+            uploadBytes += bytes.byteLength || bytes.length;
 
             // Reset one-time inputs
             if (inputState.reload) inputState.reload = false;
@@ -2988,7 +3011,11 @@ function drawEnhancedWallCracks(wall, healthPercent) {
             }
             playerCountSpan.textContent = players.size;
             pingDisplay.textContent = Math.round(ping);
-            if (networkIndicator) networkIndicator.update(ping);
+            if (serverTickDisplay) serverTickDisplay.textContent = serverTickRate;
+            if (downloadRateDisplay) downloadRateDisplay.textContent = downloadRate.toFixed(1);
+            if (uploadRateDisplay) uploadRateDisplay.textContent = uploadRate.toFixed(1);
+            if (fpsHudDisplay) fpsHudDisplay.textContent = fpsValueSpan.textContent;
+            if (networkIndicator) networkIndicator.update(ping, parseInt(fpsValueSpan.textContent, 10), serverTickRate, downloadRate, uploadRate);
 
             if (healthVignette && localPlayerState) {
                 const healthPercent = localPlayerState.health / localPlayerState.max_health;
@@ -3327,6 +3354,9 @@ function drawEnhancedWallCracks(wall, healthPercent) {
 
             dcInstance.onmessage = (event) => {
                 try {
+                    if (event.data && event.data.byteLength) {
+                        downloadBytes += event.data.byteLength;
+                    }
                     if (pingStartTime > 10) { // Calculate ping on message receipt
                         ping = Date.now() - pingStartTime;
                         pingStartTime = Date.now(); // Reset for next measurement
@@ -3339,6 +3369,8 @@ function drawEnhancedWallCracks(wall, healthPercent) {
                             switch (parsed.type) {
                                 case 'welcome':
                                     myPlayerId = parsed.playerId;
+                                    serverTickRate = parsed.serverTickRate;
+                                    if (serverTickDisplay) serverTickDisplay.textContent = serverTickRate;
                                     log(`Welcome! Your ID: ${myPlayerId}. Server Tick: ${parsed.serverTickRate}Hz`, 'success');
                                     break;
                                 case 'initial':
@@ -3399,6 +3431,7 @@ function drawEnhancedWallCracks(wall, healthPercent) {
                 if (text && text.length <= MAX_CHAT_MESSAGE_LENGTH) {
                     const bytes = createChatMessage(text);
                     dataChannel.send(bytes);
+                    uploadBytes += bytes.byteLength || bytes.length;
                     chatInput.value = '';
                 } else if (text.length > MAX_CHAT_MESSAGE_LENGTH) {
                     log(`Chat message too long (max ${MAX_CHAT_MESSAGE_LENGTH} chars).`, 'error');
@@ -4449,8 +4482,8 @@ function drawEnhancedWallCracks(wall, healthPercent) {
         class NetworkIndicator {
     constructor() {
         this.app = new PIXI.Application({
-            width: 80,
-            height: 20,
+            width: 110,
+            height: 40,
             backgroundAlpha: 0
         });
         
@@ -4460,7 +4493,7 @@ function drawEnhancedWallCracks(wall, healthPercent) {
         // Background
         const bg = new PIXI.Graphics();
         bg.beginFill(0x1F2937, 0.8);
-        bg.drawRoundedRect(0, 0, 80, 20, 5);
+        bg.drawRoundedRect(0, 0, 110, 40, 5);
         bg.endFill();
         this.container.addChild(bg);
         
@@ -4471,8 +4504,35 @@ function drawEnhancedWallCracks(wall, healthPercent) {
             fontFamily: 'monospace'
         });
         this.pingText.anchor.set(0, 0.5);
-        this.pingText.position.set(30, 10);
+        this.pingText.position.set(30, 8);
         this.container.addChild(this.pingText);
+
+        this.fpsText = new PIXI.Text('0fps', {
+            fontSize: 10,
+            fill: 0xE5E7EB,
+            fontFamily: 'monospace'
+        });
+        this.fpsText.anchor.set(0, 0.5);
+        this.fpsText.position.set(30, 18);
+        this.container.addChild(this.fpsText);
+
+        this.tickText = new PIXI.Text('0Hz', {
+            fontSize: 10,
+            fill: 0xE5E7EB,
+            fontFamily: 'monospace'
+        });
+        this.tickText.anchor.set(0, 0.5);
+        this.tickText.position.set(30, 28);
+        this.container.addChild(this.tickText);
+
+        this.rateText = new PIXI.Text('0/0', {
+            fontSize: 10,
+            fill: 0xE5E7EB,
+            fontFamily: 'monospace'
+        });
+        this.rateText.anchor.set(0, 0.5);
+        this.rateText.position.set(30, 36);
+        this.container.addChild(this.rateText);
         
         // Connection bars
         this.bars = [];
@@ -4486,13 +4546,16 @@ function drawEnhancedWallCracks(wall, healthPercent) {
         
         // Status dot
         this.statusDot = new PIXI.Graphics();
-        this.statusDot.position.set(70, 10);
+        this.statusDot.position.set(95, 10);
         this.container.addChild(this.statusDot);
     }
 
-    update(currentPing) {
+    update(currentPing, fps, tickRate, down, up) {
         // Update ping text
         this.pingText.text = Math.round(currentPing) + 'ms';
+        this.fpsText.text = fps + 'fps';
+        this.tickText.text = tickRate + 'Hz';
+        this.rateText.text = `${down.toFixed(1)}↓ ${up.toFixed(1)}↑`;
         
         // Determine connection quality
         let quality = 4;


### PR DESCRIPTION
## Summary
- show server tick, fps and network throughput in the web client
- add a `generate:flatbuffers` npm script
- document how to run the new script

## Testing
- `cargo test --no-run` *(fails: flatc not found)*
- `npm run generate:flatbuffers` *(fails: flatc is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68519304437c8321829f6e0179ad469d