### PR TITLE
Add OpenAI bot type

### DIFF
--- a/server/src/systems/bots.rs
+++ b/server/src/systems/bots.rs
@@ -10,6 +10,8 @@ use parking_lot::RwLock;
 use rand::Rng;
 use uuid::Uuid;
 
+mod open_ai_bot;
+
 #[derive(Clone, Debug)]
 pub struct BotBehavior {
     pub id: String,
@@ -26,6 +28,7 @@ pub enum BotType {
     Aggressive,
     Defensive,
     Balanced,
+    OpenAI,
 }
 
 pub struct BotManager {
@@ -86,10 +89,11 @@ impl BotManager {
                     target_position: None,
                     target_player: None,
                     last_decision_time: Instant::now(),
-                    behavior_type: match rng.gen_range(0..3) {
+                    behavior_type: match rng.gen_range(0..4) {
                         0 => BotType::Aggressive,
                         1 => BotType::Defensive,
-                        _ => BotType::Balanced,
+                        2 => BotType::Balanced,
+                        _ => BotType::OpenAI,
                     },
                     skill_level: rng.gen_range(0.4..0.9),
                     team_id,
@@ -232,6 +236,15 @@ impl BotManager {
                                 ));
                             }
                         }
+                    }
+                    BotType::OpenAI => {
+                        open_ai_bot::decide_action(
+                            bot,
+                            bot_pos,
+                            bot_health,
+                            closest_enemy,
+                            &mut rng,
+                        );
                     }
                 }
             }

--- a/server/src/systems/open_ai_bot.rs
+++ b/server/src/systems/open_ai_bot.rs
@@ -1,0 +1,34 @@
+use rand::Rng;
+use crate::core::types::{Vec2, PlayerID};
+use crate::core::constants::*;
+use super::BotBehavior;
+
+/// Simple bot behavior used for OpenAI bot example.
+/// Chooses targets similar to the balanced bot with a bit
+/// more aggression when health is high.
+pub fn decide_action(
+    bot: &mut BotBehavior,
+    bot_pos: Vec2,
+    bot_health: i32,
+    closest_enemy: Option<(PlayerID, f32, Vec2)>,
+    rng: &mut impl Rng,
+) {
+    if let Some((enemy_id, dist, enemy_pos)) = closest_enemy {
+        if dist < 350.0 || bot_health > 80 {
+            bot.target_player = Some(enemy_id);
+            bot.target_position = Some(enemy_pos);
+        } else {
+            bot.target_player = None;
+            bot.target_position = Some(Vec2::new(
+                rng.gen_range(-400.0..400.0),
+                rng.gen_range(-300.0..300.0),
+            ));
+        }
+    } else {
+        bot.target_player = None;
+        bot.target_position = Some(Vec2::new(
+            rng.gen_range((WORLD_MIN_X + 200.0)..(WORLD_MAX_X - 200.0)),
+            rng.gen_range((WORLD_MIN_Y + 200.0)..(WORLD_MAX_Y - 200.0)),
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- add new `open_ai_bot` module for custom bot logic
- extend `BotType` enum with `OpenAI` variant
- spawn `OpenAI` bots with equal probability
- handle `OpenAI` behavior in `update_bots`

## Testing
- `cargo check` *(fails: flatc missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ec85bc2a08321872a76f385d84f28